### PR TITLE
influxdb component pool_size parameter added.

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -30,6 +30,7 @@ CONF_TAGS_ATTRIBUTES = 'tags_attributes'
 CONF_COMPONENT_CONFIG = 'component_config'
 CONF_COMPONENT_CONFIG_GLOB = 'component_config_glob'
 CONF_COMPONENT_CONFIG_DOMAIN = 'component_config_domain'
+CONF_DB_CONNECTION_POOL_SIZE = "database_connection_pool_size"
 
 DEFAULT_DATABASE = 'home_assistant'
 DEFAULT_VERIFY_SSL = True
@@ -71,6 +72,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Schema({cv.string: COMPONENT_CONFIG_SCHEMA_ENTRY}),
         vol.Optional(CONF_COMPONENT_CONFIG_DOMAIN, default={}):
             vol.Schema({cv.string: COMPONENT_CONFIG_SCHEMA_ENTRY}),
+        vol.Optional(CONF_DB_CONNECTION_POOL_SIZE, default=10): cv.positive_int,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -87,7 +89,8 @@ def setup(hass, config):
     kwargs = {
         'database': conf[CONF_DB_NAME],
         'verify_ssl': conf[CONF_VERIFY_SSL],
-        'timeout': TIMEOUT
+        'timeout': TIMEOUT,
+        'pool_size': conf[CONF_DB_CONNECTION_POOL_SIZE]
     }
 
     if CONF_HOST in conf:


### PR DESCRIPTION
## Description:
Config parameter added to set influxdb component database connection pool size.


**Related issue (if applicable):**  
https://github.com/influxdata/influxdb-python/issues/349

https://github.com/influxdata/influxdb-python/pull/534/commits/ed296314b1f621610dc872920e6ccc32738d326e

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
(docs PR will be done in a couple days, not in a hurry as influxdb-python PR hasn't been merged yet)
## Example entry for `configuration.yaml` (if applicable):
```yaml
influxdb:
  database_connection_pool_size: 10
```

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
